### PR TITLE
examples need HSE library to be built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ $(HSE_ODIR):
 	mkdir -p $@
 
 .PHONY: examples
-examples:
+examples: $(HSE_LIB).$(HSE_LIBVER)
 	make -C examples PKCS11HSE_DIR=$(CURDIR)
 
 clean:


### PR DESCRIPTION
Add missing dependency in makefile. When building with high paralellism (-j option to Make) it is otherwise possible that examples will be built before the HSE library is available.